### PR TITLE
Fixed Masked Connector End Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .classpath
 .project
 /.settings
+/.idea
+*.DS_Store

--- a/src/main/java/org/aero/mtip/ModelElements/InternalBlock/Connector.java
+++ b/src/main/java/org/aero/mtip/ModelElements/InternalBlock/Connector.java
@@ -81,12 +81,12 @@ public class Connector extends CommonRelationship {
 			CameoUtils.logGUI("Supplier port not from part property.");
 			firstMemberEnd.setRole((ConnectableElement) supplier);
 		}
-		
+
 		Element clientPart = (Element) project.getElementByID(ImportXmlSysml.idConversion(xmlElement.getAttribute(XmlTagConstants.CLIENT_PART_WITH_PORT)));
 		if(clientPart != null) {
 			CameoUtils.logGUI("Client part found with id: " + clientPart.getID());
 			secondMemberEnd.setPartWithPort((com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Property)clientPart);
-			secondMemberEnd.setRole(((List<ConnectorEnd>) ((com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Property) clientPart).get_connectorEndOfPartWithPort()).get(0).getRole());
+			secondMemberEnd.setRole((ConnectableElement) client);
 			StereotypesHelper.addStereotype(secondMemberEnd, nestedConnectorEndStereotype);
 			StereotypesHelper.setStereotypePropertyValue(secondMemberEnd, elementPropertyPathStereotype, "propertyPath", clientPart);
 		} else {

--- a/src/main/java/org/aero/mtip/XML/Import/ImportXmlSysml.java
+++ b/src/main/java/org/aero/mtip/XML/Import/ImportXmlSysml.java
@@ -1068,7 +1068,14 @@ public class ImportXmlSysml {
 	public static Element GetImportedOwner(XMLItem modelElement, HashMap<String, XMLItem> parsedXML) {
 		String ownerID = modelElement.getParent();
 		XMLItem ownerElement = parsedXML.get(ownerID);
-		
+
+//		If an owner is specified by ID but no element is provided, attempt to query the project for an existing element
+		if(ownerID != null && ownerElement == null){
+			Element element = (Element) project.getElementByID(ownerID);
+			if(element != null){
+				return element;
+			}
+		}
 		if(modelElement.getParent().trim().isEmpty() || ownerElement == null) {
 			return primaryLocation; // Set owned equal to Primary model if no hasParent attribute in XML -> parent field in XMLItem == ""
 		} 

--- a/src/main/java/org/aero/mtip/XML/Import/ImportXmlSysmlAction.java
+++ b/src/main/java/org/aero/mtip/XML/Import/ImportXmlSysmlAction.java
@@ -33,6 +33,10 @@ public class ImportXmlSysmlAction extends MDAction {
 		super(id, name, null, null);
 	}
 	public void actionPerformed(ActionEvent e) {
+		importXmlSysml();
+	}
+
+	public static void importXmlSysml() {
 		ImportXmlSysml.resetImportParameters();
 		Project project = Application.getInstance().getProject();
 		if(project == null) {


### PR DESCRIPTION
This PR fixes bug addressed in Issue #2 related to Binding Connectors being masked on the Client side connector. Looking at the code, supplier role and client role were implemented differently. I changed the client role to match the way supplier role was set, and the bug resolved itself.

There may be a reason from other use cases the keep the client side role the way it was. If so, we will need to implement some sort of if statement logic based on the connector type.

Also, I pulled the importXmlSysml action into its own method instead of nesting it in the action listener. This allows other plugins to use the public method.